### PR TITLE
🔐 Secure admin site with proxy and SSL

### DIFF
--- a/ov-nginx/nginx.conf
+++ b/ov-nginx/nginx.conf
@@ -29,7 +29,7 @@ http {
     ssl_certificate /etc/nginx/ssl/live/ov-admin.k8s.wgbhdigital.org/fullchain.pem;
     ssl_certificate_key /etc/nginx/ssl/live/ov-admin.k8s.wgbhdigital.org/privkey.pem;
     location / {
-      proxy_pass http://ov-admin;
+      proxy_pass http://ov-wag;
     }
   }
 }

--- a/ov-nginx/nginx.conf
+++ b/ov-nginx/nginx.conf
@@ -26,10 +26,10 @@ http {
   server {
     listen 443;
     server_name ov-admin.k8s.wgbhdigital.org;
-    ssl_certificate /etc/nginx/ssl/live/$host/fullchain.pem;
-    ssl_certificate_key /etc/nginx/ssl/live/$host/privkey.pem;
+    ssl_certificate /etc/nginx/ssl/live/ov-admin.k8s.wgbhdigital.org/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/live/ov-admin.k8s.wgbhdigital.org/privkey.pem;
     location / {
-      proxy_pass http://ov-admin
+      proxy_pass http://ov-admin;
     }
   }
 }

--- a/ov-nginx/nginx.conf
+++ b/ov-nginx/nginx.conf
@@ -4,32 +4,21 @@ events {
 
 http {
 
+  # Admin
+  server {
+    listen 80;
+    server_name ov-admin.k8s.wgbhdigital.org;
+    location / {
+      proxy_pass http://ov-wag;
+    }
+  }
+
   # Frontend
   server {
     listen 80 default_server;
     server_name ovfrontend.k8s.wgbhdigital.org;
     location / {
       proxy_pass http://ov-frontend:3000;
-    }
-  }
-
-  # Admin redirect to https
-  server {
-    listen 80;
-    server_name ov-admin.k8s.wgbhdigital.org;
-    location / {
-      return 301 https://$host$request_uri;
-    }
-  }
-
-  # Admin
-  server {
-    listen 443;
-    server_name ov-admin.k8s.wgbhdigital.org;
-    ssl_certificate /etc/nginx/ssl/live/ov-admin.k8s.wgbhdigital.org/fullchain.pem;
-    ssl_certificate_key /etc/nginx/ssl/live/ov-admin.k8s.wgbhdigital.org/privkey.pem;
-    location / {
-      proxy_pass http://ov-wag;
     }
   }
 }

--- a/ov-nginx/nginx.conf
+++ b/ov-nginx/nginx.conf
@@ -3,10 +3,21 @@ events {
 }
 
 http {
+  # Frontend
   server {
-    listen 80 default_server;
-    location / {
+    listen 80;
+    server_name ovfrontend.k8s.wgbhdigital.org;
+   location / {
       proxy_pass http://ov-frontend:3000;
+    }
+  }
+
+  # Admin
+  server {
+     listen 80;
+     server_name ov-admin.k8s.wgbhdigital.org;
+     location / {
+      proxy_pass http://ov-wag;
     }
   }
 }

--- a/ov-nginx/nginx.conf
+++ b/ov-nginx/nginx.conf
@@ -3,21 +3,33 @@ events {
 }
 
 http {
+
   # Frontend
   server {
-    listen 80;
+    listen 80 default_server;
     server_name ovfrontend.k8s.wgbhdigital.org;
-   location / {
+    location / {
       proxy_pass http://ov-frontend:3000;
+    }
+  }
+
+  # Admin redirect to https
+  server {
+    listen 80;
+    server_name ov-admin.k8s.wgbhdigital.org;
+    location / {
+      return 301 https://$host$request_uri;
     }
   }
 
   # Admin
   server {
-     listen 80;
-     server_name ov-admin.k8s.wgbhdigital.org;
-     location / {
-      proxy_pass http://ov-wag;
+    listen 443;
+    server_name ov-admin.k8s.wgbhdigital.org;
+    ssl_certificate /etc/nginx/ssl/live/$host/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/live/$host/privkey.pem;
+    location / {
+      proxy_pass http://ov-admin
     }
   }
 }


### PR DESCRIPTION
# Admin proxy
## `ov-nginx`
- Adds ingress control for admin site: ov-admin.k8s.wgbhdigital.org
- `proxy_pass` to `ov-wag`
- Adds `server_name` to frontend config: ovfrontend.k8s.wgbhdigital.org

Related to [ov-wag #48](https://github.com/WGBH-MLA/ov-wag/issues/48)
Also: Closes #34 