### PR TITLE
🎭 Production

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -118,30 +118,19 @@ For each workload:
 
 1.  Set environment variables
 
-    Create a new config map with the necessary environment variables.
+    Create a new config map and set the values from the config files below.
 
-    `Resources > Config > Add Config Map`
+    Under `Environment Variables` Click `Add From Source` and set `type: Config Map`
 
-    ```bash title="ov-wag-config"
-    OV_DB_ENGINE=django.db.backends.postgresql
-    OV_DB_PORT=5432
-    OV_DB_NAME=postgres
-    OV_DB_USER=postgres
-    ```
+    Set the name of the config map and save the settings.
 
-    Click `Add From Source` and set `type: Config Map`
-
-    Select the name of the config map
+    Restart any container using that config.
 
 1.  Enter secrets
 
     Add a new secret with any secrets that need to be available.
 
     Click `Add From Source` and set `type: Secret`
-
-    ```bash title="ov-wag-secret"
-    OV_DB_PASSWORD=p@ssW0rd!
-    ```
 
 !!! todo "TODO: Enumerate kube steps"
 
@@ -165,16 +154,22 @@ The following services are needed to run the stack:
 - image: `wgbhmla/ov-wag`
 - config:
 
-      ```bash title="ov-wag environment"
+      ```bash title="ov-wag-config"
+      DJANGO_SETTINGS_MODULE=ov_wag.settings.production
+
       OV_DB_ENGINE=django.db.backends.postgresql
+      OV_DB_HOST=db
       OV_DB_PORT=5432
       OV_DB_NAME=postgres
       OV_DB_USER=postgres
+
+      OV_ALLOWED_HOSTS=ov-wag
+      OV_TRUSTED_ORIGINS=http://ov-admin.k8s.wgbhdigital.org/
       ```
 
 - secrets:
 
-      ```bash title="ov-wag.secrets"
+      ```bash title="ov-wag-secrets"
       OV_DB_PASSWORD=p@ssW0rd!
       ```
 
@@ -191,16 +186,27 @@ The following services are needed to run the stack:
 
 - image: `wgbhmla/ov-nginx`
 
-      - preconfigured with `nginx.conf`
+      preconfigured with `nginx.conf`
+      - ov-admin: proxy pass to `http://ov-wag`
       - proxy pass to `http://ov-frontend:3000`
 
 - endpoints:
 
-      - `80/http`
+      - `443/http`
 
 - Load Balancing:
 
-      - hostname: `[public url]`
+      - `ov-admin`
+        - Hostname: `http://ov-admin.k8s.wgbhdigital.org`
+        - Path: `/`
+        - Target: `ov-nginx`
+        - Port: 80
+
+      - `ov-front`
+        - Hostname: `http://ovfrontend.k8s.wgbhdigital.org`
+        - Path: `/`
+        - Target: `ov-nginx`
+        - Port: 80
 
 #### jumpbox
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -103,7 +103,7 @@ If deploying for the first time, Kubernetes must be configured to receive deploy
 
 ### Create workloads
 
-For each workload:
+#### For each workload:
 
 1.  From the Workloads tab of the project, Click `Deploy`
 1.  Enter the name of the service
@@ -124,9 +124,13 @@ For each workload:
 
     Set the name of the config map and save the settings.
 
-    Restart any container using that config.
+    Restart any running container using that config.
 
-1.  Enter secrets
+1.  Mount volumes
+
+    If needed, create an external volume under the `Volumes` tab and mount it to the specified location.
+
+1.  Add secrets
 
     Add a new secret with any secrets that need to be available.
 
@@ -143,6 +147,12 @@ The following services are needed to run the stack:
 #### db
 
 - image: `postgres:14.2-alpine`
+
+- volumes:
+
+      - `ov-db`: `/var/lib/postgresql/data`
+        - `Read-Only=False`
+
 - secrets:
 
       ```bash title="db secrets"
@@ -191,15 +201,18 @@ The following services are needed to run the stack:
 
 - image: `wgbhmla/ov-nginx`
 
-        - preconfigured with `nginx.conf`
+      - preconfigured with `nginx.conf`
 
-        - Admin: [ov-admin.k8s.wgbhdigital.org](https://ov-admin.k8s.wgbhdigital.org/)
-            - proxy pass to `http://ov-wag`
+  - Admin site: [ov-admin.k8s.wgbhdigital.org](https://ov-admin.k8s.wgbhdigital.org/)
 
-        - `/static` served from `/static/` mounted volume
-        - `/media` served from `/media/` mounted volume
+    - proxy pass to `http://ov-wag`
 
-        - proxy pass to `http://ov-frontend:3000`
+  - `/static` served from `/static/` mounted volume
+  - `/media` served from `/media/` mounted volume
+
+  - Frontend: [ovfrontend.k8s.wgbhdigital.org](http://ovfrontend.k8s.wgbhdigital.org/)
+
+    - proxy pass to `http://ov-frontend:3000`
 
 !!! todo "external `/media` host"
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -152,6 +152,11 @@ The following services are needed to run the stack:
 #### ov-wag (backend)
 
 - image: `wgbhmla/ov-wag`
+- volumes:
+
+      - `ov-static`: `/app/static/`: `rw`
+      - `ov-media`: `/app/media/`: `rw`
+
 - config:
 
       ```bash title="ov-wag-config"
@@ -186,13 +191,29 @@ The following services are needed to run the stack:
 
 - image: `wgbhmla/ov-nginx`
 
-      preconfigured with `nginx.conf`
-      - ov-admin: proxy pass to `http://ov-wag`
-      - proxy pass to `http://ov-frontend:3000`
+        - preconfigured with `nginx.conf`
+
+        - Admin: [ov-admin.k8s.wgbhdigital.org](https://ov-admin.k8s.wgbhdigital.org/)
+            - proxy pass to `http://ov-wag`
+
+        - `/static` served from `/static/` mounted volume
+        - `/media` served from `/media/` mounted volume
+
+        - proxy pass to `http://ov-frontend:3000`
+
+!!! todo "external `/media` host"
+
+    We will  need to change this configuration when we switch to using an s3 bucket, or other external media host.
+
+- volumes:
+
+      - `ov-static`: `/static/`: `r`
+      - `ov-media`: `/media/`: `r`
 
 - endpoints:
 
       - `443/http`
+      - Secured with SSL cert from IT certbot
 
 - Load Balancing:
 

--- a/ov-nginx/nginx.conf
+++ b/ov-nginx/nginx.conf
@@ -8,16 +8,17 @@ http {
   server {
     listen 80;
     server_name ov-admin.k8s.wgbhdigital.org;
+
     location /admin {
-      proxy_pass http://ov-wag/admin;
+      proxy_pass http://ov-wag/;
     }
 
     location /static {
-      root /static/;
+      alias /static/;
     }
 
     location /media {
-      root /media/;
+      alias /media/;
     }
   }
 
@@ -25,6 +26,7 @@ http {
   server {
     listen 80 default_server;
     server_name ovfrontend.k8s.wgbhdigital.org;
+
     location / {
       proxy_pass http://ov-frontend:3000;
     }

--- a/ov-nginx/nginx.conf
+++ b/ov-nginx/nginx.conf
@@ -11,9 +11,13 @@ http {
     location /admin {
       proxy_pass http://ov-wag/admin;
     }
+
     location /static {
       root /static/;
     }
+
+    location /media {
+      root /media/;
     }
   }
 

--- a/ov-nginx/nginx.conf
+++ b/ov-nginx/nginx.conf
@@ -8,8 +8,12 @@ http {
   server {
     listen 80;
     server_name ov-admin.k8s.wgbhdigital.org;
-    location / {
-      proxy_pass http://ov-wag;
+    location /admin {
+      proxy_pass http://ov-wag/admin;
+    }
+    location /static {
+      root /static/;
+    }
     }
   }
 

--- a/ov-nginx/nginx.conf
+++ b/ov-nginx/nginx.conf
@@ -9,7 +9,7 @@ http {
     listen 80;
     server_name ov-admin.k8s.wgbhdigital.org;
 
-    location /admin {
+    location / {
       proxy_pass http://ov-wag/;
     }
 


### PR DESCRIPTION
# Production
Adds production settings with [ov-wag#50](https://github.com/WGBH-MLA/ov-wag/pull/50)

## `nginx.conf`
New routes for admin site:
- `/static`
  - `alias /static`
- `/media`
  - `alias /media`

## Volumes
Create new Rancher volumes:
- `ov-db`
  - Holds `db` data
  - `ov-db`:`/var/lib/postgresql/data`
    - `Read-Only=false` - We might scale to more than one db instance eventually
- `ov-static`
  - For serving static files between `ov-wag` and `ov-nginx`
  - `ov-wag`:`/app/static/`:`rw`
  - `ov-nginx`:`/static/`:`r`
- `ov-media`
  - For serving media files between `ov-wag` and `ov-nginx`
    - This is a temporary solution until we switch to s3, or other external media server
  - `ov-wag`:`/app/media/`:`rw`
  - `ov-nginx`:`/media/`:`r`


## Docs
Documents production settings:
- Added config settings
- Added volume settings
- Cleaned steps