### PR TITLE
🧤 Add `mime.types` to nginx config

### DIFF
--- a/ov-nginx/nginx.conf
+++ b/ov-nginx/nginx.conf
@@ -4,6 +4,8 @@ events {
 
 http {
 
+  include /etc/nginx/mime.types;
+  
   # Admin
   server {
     listen 80;


### PR DESCRIPTION
# MIME types
Includes `mime.types` with nginx config.

Closes #41, production admin site display bug.