### PR TITLE
♻️ Elasticsearch cert renewal

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,4 +9,4 @@ on:
 jobs:
   update:
     name: 🦿 Update dependencies
-    uses: WGBH-MLA/.github/.github/workflows/update.yml@dependabot/github_actions/dot-github/workflows/peter-evans/create-pull-request-7
+    uses: WGBH-MLA/.github/.github/workflows/update.yml@main

--- a/elasticsearch/elastic-certs.sh
+++ b/elasticsearch/elastic-certs.sh
@@ -1,37 +1,50 @@
 #!/bin/bash
 
-# This script will update the elastic-certs secret with the latest certificate from Traefik
-
-DOMAIN=elastic.wgbh-mla.org
-
-if [ -z "$DOMAIN" ]; then
-    echo "Please provide a domain"
-    echo "Usage: $0 <domain>"
+help() {
+    echo
+    echo "Usage: $0 <update-elasticsearch|update-kibana>"
+    echo
+    echo This script gets the latest certificate from Traefik
+    echo and updates the Elasticsearch or Kibana k8s secret
+    echo
     exit 1
-fi
+}
 
->&2 echo "DOMAIN: $DOMAIN"
+get-traefik() {
+    # Get the name of the running Traefik pod
+    TRAEFIK=$(kubectl -n traefik -o json get po | jq -r .items[0].metadata.name)
 
-# Get the name of the running Traefik pod
-TRAEFIK=$(kubectl -n traefik -o json get po | jq -r .items[0].metadata.name)
+    if [ -z "$TRAEFIK" ]; then
+        echo "Traefik pod not found"
+        exit 1
+    fi
+    echo "$TRAEFIK"
+}
 
-if [ -z "$TRAEFIK" ]; then
-    echo "Traefik pod not found"
-    exit 1
-fi
+get-cert() {
+    # Get the certificate object from Traefik that matches the domain
+    DOMAIN=$1
+    CERT=$(kubectl exec -n traefik $TRAEFIK -- cat /ssl-certs/acme-production.json | jq --arg domain $DOMAIN -r '.production.Certificates[] | select( .domain.main==$domain ).certificate')
 
->&2 echo "TRAEFIK: $TRAEFIK"
+    if [ -z "$CERT" ]; then
+        echo "Certificate not found for $DOMAIN"
+        exit 1
+    fi
+    echo "$CERT"
+}
 
-# Get the certificate object from Traefik that matches the domain
-CERT=$(kubectl exec -n traefik $TRAEFIK -- cat /ssl-certs/acme-production.json | jq --arg domain $DOMAIN -r '.production.Certificates[] | select( .domain.main==$domain ).certificate' )
+update-elasticsearch() {
+    # Update the Elasticsearch secret with the latest certificate
+    TRAEFIK=$(get-traefik)
+    CERT=$(get-cert "elastic.wgbh-mla.org")
+    kubectl -n elastic patch secret elastic-certs -p "{\"data\":{\"tls.crt\":\"$CERT\"}}"
+}
 
-if [ -z "$CERT" ]; then
-    echo "Certificate not found"
-    exit 1
-fi
+update-kibana() {
+    # Update the Kibana secret with the latest certificate
+    TRAEFIK=$(get-traefik)
+    CERT=$(get-cert "search.wgbh-mla.org")
+    kubectl -n elastic patch secret kibana-certs -p "{\"data\":{\"tls.crt\":\"$CERT\"}}"
+}
 
-# echo "$CERT"
-
-# Modify the k8s secret
-# When modifying the kibana secret, be sure to modify the `kibana-certs` secret
-kubectl -n elastic patch secret elastic-certs -p "{\"data\":{\"tls.crt\":\"$CERT\"}}"
+"$@" || help

--- a/elasticsearch/elastic-certs.sh
+++ b/elasticsearch/elastic-certs.sh
@@ -7,7 +7,6 @@ help() {
     echo This script gets the latest certificate from Traefik
     echo and updates the Elasticsearch or Kibana k8s secret
     echo
-    exit 1
 }
 
 get-traefik() {
@@ -47,4 +46,4 @@ update-kibana() {
     kubectl -n elastic patch secret kibana-certs -p "{\"data\":{\"tls.crt\":\"$CERT\"}}"
 }
 
-"$@" || help
+"$@" || (help && exit 1)

--- a/elasticsearch/elastic-certs.sh
+++ b/elasticsearch/elastic-certs.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# This script will update the elastic-certs secret with the latest certificate from Traefik
+
+DOMAIN=elastic.wgbh-mla.org
+
+if [ -z "$DOMAIN" ]; then
+    echo "Please provide a domain"
+    echo "Usage: $0 <domain>"
+    exit 1
+fi
+
+>&2 echo "DOMAIN: $DOMAIN"
+
+# Get the name of the running Traefik pod
+TRAEFIK=$(kubectl -n traefik -o json get po | jq -r .items[0].metadata.name)
+
+if [ -z "$TRAEFIK" ]; then
+    echo "Traefik pod not found"
+    exit 1
+fi
+
+>&2 echo "TRAEFIK: $TRAEFIK"
+
+# Get the certificate object from Traefik that matches the domain
+CERT=$(kubectl exec -n traefik $TRAEFIK -- cat /ssl-certs/acme-production.json | jq --arg domain $DOMAIN -r '.production.Certificates[] | select( .domain.main==$domain ).certificate' )
+
+if [ -z "$CERT" ]; then
+    echo "Certificate not found"
+    exit 1
+fi
+
+# echo "$CERT"
+
+# Modify the k8s secret
+# When modifying the kibana secret, be sure to modify the `kibana-certs` secret
+kubectl -n elastic patch secret elastic-certs -p "{\"data\":{\"tls.crt\":\"$CERT\"}}"


### PR DESCRIPTION
# Elasticsearch
Creates `elastic-certs.sh` script to pull renewed SSL certificate from `traefik` and patch the kubernetes secret in the `elastic` namespace.

## Usage
```sh
# Update elastic cert
./elastic-certs.sh update-elasticsearch
# Update kibana cert
./elastic-certs.sh update-kibana
```

Closes #56